### PR TITLE
Add option to disable web security

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -35,6 +35,7 @@ program
   .option('-v, --verbose', 'print verbose info')
   .option('-o, --output <path>', 'path to test output file', RESULTS_FILE_NAME)
   .option('--xunit', 'uses xunit mocha reporter, WebConsole used by default')
+  .option('--disable-security', 'disable web security in electron (i.e. to allow cross-domain requests)')
   .parse(process.argv);
 
 //init logger
@@ -55,5 +56,6 @@ require('../src/tester')({
   //for simplicity we doesn't allow to define other reporter types
   //most of mocha's build-in reportes are meant to be used with node.js
   //right we can use a default WebConsole reporter or XUnit reporter usefull for CI
-  reporter : program.xunit ? REPORTERS.XUNIT : REPORTERS.WEB_CONSOLE
+  reporter : program.xunit ? REPORTERS.XUNIT : REPORTERS.WEB_CONSOLE,
+  disableSecurity: program.disableSecurity
 });

--- a/src/tester.js
+++ b/src/tester.js
@@ -110,7 +110,10 @@ module.exports = config => {
     openDevTools: {
       mode: 'detach'
     },
-    show: config.headfull
+    show: config.headfull,
+    webPreferences: {
+      webSecurity: !config.disableSecurity
+    }
   });
 
   //read configuration from file


### PR DESCRIPTION
Electron is strict with regards to cross-domain requests.
If Content-Type is application/json, then it sends a preflight
requests which should be handled by server properly. This might not
be preferrable for the tested web server that is configured in production
mode with CORS disabled.

Cross-domain requests are useful for controling environment of system
under test i.e. setting DBus properties.